### PR TITLE
Add UID to shopify.extension.toml

### DIFF
--- a/extensions/discounts-allocator-js/shopify.extension.toml
+++ b/extensions/discounts-allocator-js/shopify.extension.toml
@@ -5,6 +5,7 @@ handle = "discounts-allocator-js"
 name = "t:name"
 description = "t:description"
 type = "function"
+uid = "ccf7edf4-a12d-b60a-9d4a-1cb8691864d6ec6a83e2"
 
   [[extensions.targeting]]
   target = "purchase.discounts-allocator.run"


### PR DESCRIPTION
Add deterministic UID based on extension handle

Relates to: https://github.com/Shopify/shopify-dev/issues/65152

Purpose:
The uid field is now required in shopify.extension.toml files for all extensions. UIDs are generated deterministically from the handle to ensure consistent values and allow users to safely copy examples without replacing placeholders.